### PR TITLE
leaderboard + results

### DIFF
--- a/backend/src/game.ts
+++ b/backend/src/game.ts
@@ -64,6 +64,7 @@ function endQuestion(gameId: GameId) {
 		return;
 	}
 
+	let leaderboard: { name: string; score: number }[] = [];
 	users.forEach(function (value: UserId) {
 		let user = game.users.get(value);
 		if (!user) return;
@@ -88,7 +89,20 @@ function endQuestion(gameId: GameId) {
 		if (sock.readyState === WebSocket.OPEN) {
 			sendMessage(sock, 'endQuestion', resp);
 		}
+		leaderboard.push({ name: user.name, score: endResp.score });
 	});
+
+	// host view
+	leaderboard.sort((a, b) => b.score - a.score);
+	let hostResp = {
+		correctAnswers: game.quizData.questions[game.activeQuestion].correctAnswers,
+		leaderBoard: leaderboard,
+	};
+	const hostId = game.hostId;
+	const hostSocket = userSockets.get(hostId);
+	if (hostSocket !== undefined && hostSocket.readyState === WebSocket.OPEN) {
+		sendMessage(hostSocket, 'endQuestion', hostResp);
+	}
 	return;
 }
 
@@ -294,6 +308,53 @@ export default function registerGameRoutes(app: Express) {
 
 		game.users.set(id, { name: username, answers: [], scores: [], times: [] });
 		res.status(201).json({ ok: true, id });
+		return;
+	});
+
+	app.get('/games/:id/results', (req, res) => {
+		const gameId = req.params.id;
+		const game = games.get(gameId);
+
+		if (!game) {
+			return res
+				.status(404)
+				.send({ ok: false, err: `Game ${gameId} not found` });
+		}
+
+		// gets player name with their responding total score and which questions they got right
+		let results: { name: string; score: number; correctAnswers: number[] }[] =
+			[];
+		const users = getUsers(game);
+		game.users.forEach((user) => {
+			const score = user.scores.reduce((a, b) => a + b, 0);
+			// indices of questions answered correctly
+			const correctAnswers: number[] = [];
+			game.quizData.questions.forEach((question, questionIndex) => {
+				if (question.correctAnswers.includes(user.answers[questionIndex])) {
+					correctAnswers.push(questionIndex);
+				}
+			});
+			results.push({
+				name: user.name,
+				score: score,
+				correctAnswers: correctAnswers,
+			});
+		});
+		results.sort((a, b) => b.score - a.score);
+
+		// host end results
+		const userSockets = connections.get(gameId);
+		if (userSockets === undefined) {
+			// Player List Not in Connections
+			return;
+		}
+		const hostId = game.hostId;
+		const hostSocket = userSockets.get(hostId);
+		if (hostSocket !== undefined && hostSocket.readyState === WebSocket.OPEN) {
+			sendMessage(hostSocket, 'results', results);
+		}
+
+		res.status(200).send({ ok: true });
 		return;
 	});
 }


### PR DESCRIPTION
Combined both tasks into one branch because they're similar to each other. LMK if there are any changes I need to make!

Changes: 
1) Modified endQuestion so that it returns only the correctAnswers and leaderboard to the host. The leaderboard encapsulates all the players and is sorted by descending scores (ex: {name: 'username', score: 10} ...). 

2) Added API for results, which should be called after there are no more questions to answer. As of now, it only sends the results to the host, but I can also implement what should be sent to students as well according to Gea's post-game stat designs.  The results, similarly to the leaderboard, consist of all player names and are sorted by scores but also show which questions each player got correct. 