### PR TITLE
Add documentation of how to authenticate the WebSocket connection

### DIFF
--- a/api-docs/interface/auth.md
+++ b/api-docs/interface/auth.md
@@ -4,7 +4,7 @@
 
 The player create and game create endpoints now return an additional `token` field, of type `string`. Every client stores this token somehow (probably local storage or session storage). Clients do not care what the value is, they just pass it to the server. For any endpoint that requires authentication (really just any endpoint), clients include the header `Authorization: Bearer <token>`. Servers reply with HTTP 401 if the token is missing and 403 if it is incorrect.
 
-When the client opens its WebSocket connection, it includes the token as a querystring parameter `token`, such as: `/connect?gameId=12345&playerId=00000000&token=xyz`. This has to be used since you can't specify headers when opening a websocket.
+When the client opens its WebSocket connection, it includes the token as a querystring parameter `token`, such as: `/connect?gameId=12345&playerId=00000000&token=xyz`. This has to be used since you can't specify headers when opening a websocket. If the authentication is missing or incorrect, the server should immediately close the connection with an appropriate error.
 
 ## Server-side: generating a token
 

--- a/api-docs/interface/auth.md
+++ b/api-docs/interface/auth.md
@@ -4,6 +4,8 @@
 
 The player create and game create endpoints now return an additional `token` field, of type `string`. Every client stores this token somehow (probably local storage or session storage). Clients do not care what the value is, they just pass it to the server. For any endpoint that requires authentication (really just any endpoint), clients include the header `Authorization: Bearer <token>`. Servers reply with HTTP 401 if the token is missing and 403 if it is incorrect.
 
+When the client opens its WebSocket connection, it includes the token as a querystring parameter `token`, such as: `/connect?gameId=12345&playerId=00000000&token=xyz`. This has to be used since you can't specify headers when opening a websocket.
+
 ## Server-side: generating a token
 
 The server uses [HMAC](https://en.wikipedia.org/wiki/HMAC)-SHA256, which combines a secret and some input to create a hash that could only have been created by someone knowing both values. The advantage of this is that the server doesn't actually have to store players' tokens, as it can just verify any token that it receives by recomputing what the token for that player should be and checking that they are equal.

--- a/api-docs/interface/server-socket.md
+++ b/api-docs/interface/server-socket.md
@@ -1,7 +1,7 @@
 # Websockets
 
 ## Server.ts
-Connect to the websocket at `/connect?gameId={game ID}&playerId={player ID}`
+Connect to the websocket at `/connect?gameId={game ID}&playerId={player ID}&token={authentication token}`
 - Calls handleConnection()
 
 ### Data Structs:


### PR DESCRIPTION
I neglected this in the initial auth documentation. Very little sensitive information is sent over the websocket, so we probably could have done without it, but I think it's still good to do this for completion.